### PR TITLE
Create PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+## 🎫 Related asana ticket
+<!-- Attach a link to Asana ticket that this PR addresses -->
+
+
+## 📌 Description
+<!-- What this PR does and why it is needed. -->
+
+
+## 📝 Additional Notes
+<!-- Any special instructions or breaking changes that is worth mentioning -->
+
+
+## ✅ Checklist
+
+- [ ] **Code Complete**: All coding tasks and changes have been implemented, and the code is functionally complete.
+- [ ] **Acceptance Criteria Met**: The code meets all 'must-have' acceptance criteria outlined in the user story.
+- [ ] **Security Measures Implemented**: Appropriate security measures have been implemented to protect against common vulnerabilities and adhere to security standards.
+- [ ] **Regression Testing Conducted**: Regression tests have been executed to ensure that the new changes do not introduce any unexpected issues or regressions in existing functionality.
+#### Work in progress - applicable to the extent that it is feasible
+- [ ] **Integration Tests Passed**: Integration tests have been performed to validate the interaction of the code with other system components, and they pass successfully.
+- [ ] **Deployment Ready**: The code is ready for fully automatic deployment to the target environment, including any necessary configuration changes, environment setup, and dependencies.
+#### For production:
+- [ ] **Stakeholder Approval**: The stakeholders, including the product owner or client, have reviewed and approved the work, and any feedback or required changes have been addressed.


### PR DESCRIPTION
This PR closes https://github.com/councyl/electra/pull/204, by adding the PR template that serves as organization-wide default for all repositories, which prevents having a copy of the template in multiple repositories.